### PR TITLE
Server Blacklist

### DIFF
--- a/bungeecord/src/main/java/com/github/dominik48n/party/bungee/PartyBungeePlugin.java
+++ b/bungeecord/src/main/java/com/github/dominik48n/party/bungee/PartyBungeePlugin.java
@@ -25,15 +25,16 @@ import com.github.dominik48n.party.bungee.listener.UpdateCheckerListener;
 import com.github.dominik48n.party.config.ProxyPluginConfig;
 import com.github.dominik48n.party.redis.RedisManager;
 import com.github.dominik48n.party.util.UpdateChecker;
-import java.io.File;
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import net.kyori.adventure.platform.bungeecord.BungeeAudiences;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 public class PartyBungeePlugin extends Plugin {
 
@@ -81,7 +82,7 @@ public class PartyBungeePlugin extends Plugin {
         final BungeeCommandManager bungeeCommandManager = new BungeeCommandManager(userManager, this);
 
         this.getProxy().getPluginManager().registerListener(this, new OnlinePlayersListener(userManager, this));
-        this.getProxy().getPluginManager().registerListener(this, new SwitchServerListener(userManager, this.getLogger()));
+        this.getProxy().getPluginManager().registerListener(this, new SwitchServerListener(userManager, this.config.serverSwitchConfig(), this.getLogger()));
 
         this.getProxy().getPluginManager().registerCommand(
                 this,

--- a/bungeecord/src/main/java/com/github/dominik48n/party/bungee/PartyBungeePlugin.java
+++ b/bungeecord/src/main/java/com/github/dominik48n/party/bungee/PartyBungeePlugin.java
@@ -25,16 +25,15 @@ import com.github.dominik48n.party.bungee.listener.UpdateCheckerListener;
 import com.github.dominik48n.party.config.ProxyPluginConfig;
 import com.github.dominik48n.party.redis.RedisManager;
 import com.github.dominik48n.party.util.UpdateChecker;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import net.kyori.adventure.platform.bungeecord.BungeeAudiences;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 
 public class PartyBungeePlugin extends Plugin {
 

--- a/bungeecord/src/main/java/com/github/dominik48n/party/bungee/listener/SwitchServerListener.java
+++ b/bungeecord/src/main/java/com/github/dominik48n/party/bungee/listener/SwitchServerListener.java
@@ -47,7 +47,7 @@ public class SwitchServerListener extends SwitchServer<ProxiedPlayer> implements
     }
 
     @Override
-    public void logJsonProcessingException(JsonProcessingException jsonProcessingException) {
+    public void logJsonProcessingException(final @NotNull JsonProcessingException jsonProcessingException) {
         this.logger.log(Level.SEVERE, "Failed to get party.", jsonProcessingException);
     }
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     testImplementation("com.google.guava:guava:31.1-jre")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.14.2")
     testImplementation("org.mockito:mockito-core:5.3.1")
+    testImplementation("org.mockito:mockito-junit-jupiter:5.3.1")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 }

--- a/common/src/main/java/com/github/dominik48n/party/config/Document.java
+++ b/common/src/main/java/com/github/dominik48n/party/config/Document.java
@@ -156,9 +156,9 @@ public class Document {
     }
 
     static @NotNull Collector<JsonNode, List<String>, List<String>> stringCollector() {
-        Supplier<List<String>> supplier = ArrayList::new;
-        BiConsumer<List<String>, JsonNode> accumulator = (stringList, jsonNode) -> stringList.add(jsonNode.asText());
-        BinaryOperator<List<String>> combiner = Document::stringListCombiner;
+        final Supplier<List<String>> supplier = ArrayList::new;
+        final BiConsumer<List<String>, JsonNode> accumulator = (stringList, jsonNode) -> stringList.add(jsonNode.asText());
+        final BinaryOperator<List<String>> combiner = Document::stringListCombiner;
         return Collector.of(supplier, accumulator, combiner);
     }
 

--- a/common/src/main/java/com/github/dominik48n/party/config/ProxyPluginConfig.java
+++ b/common/src/main/java/com/github/dominik48n/party/config/ProxyPluginConfig.java
@@ -16,9 +16,10 @@
 
 package com.github.dominik48n.party.config;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.File;
 import java.io.IOException;
-import org.jetbrains.annotations.NotNull;
 
 public class ProxyPluginConfig {
 
@@ -32,6 +33,7 @@ public class ProxyPluginConfig {
     private final @NotNull MessageConfig messageConfig;
     private final @NotNull RedisConfig redisConfig;
     private final @NotNull PartyConfig partyConfig;
+    private final @NotNull SwitchServerConfig serverSwitchConfig;
 
     private final boolean updateChecker;
 
@@ -43,6 +45,7 @@ public class ProxyPluginConfig {
         this.redisConfig = RedisConfig.fromDocument(document.getDocument("redis"));
         this.messageConfig = MessageConfig.fromDocument(document.getDocument("messages"));
         this.partyConfig = PartyConfig.fromDocument(document.getDocument("party"));
+        this.serverSwitchConfig = SwitchServerConfig.fromDocument(document.getDocument("switch_server"));
 
         this.updateChecker = document.getBoolean("update_checker", true);
     }
@@ -58,6 +61,9 @@ public class ProxyPluginConfig {
     public @NotNull PartyConfig partyConfig() {
         return this.partyConfig;
     }
+    public @NotNull SwitchServerConfig serverSwitchConfig() {
+        return this.serverSwitchConfig;
+    }
 
     public boolean updateChecker() {
         return this.updateChecker;
@@ -69,6 +75,7 @@ public class ProxyPluginConfig {
                 .append("redis", this.redisConfig.toDocument())
                 .append("party", this.partyConfig.toDocument())
                 .append("messages", this.messageConfig.toDocument())
+                .append("switch_server", this.serverSwitchConfig.toDocument())
                 .writeToFile(file);
     }
 }

--- a/common/src/main/java/com/github/dominik48n/party/config/SwitchServerConfig.java
+++ b/common/src/main/java/com/github/dominik48n/party/config/SwitchServerConfig.java
@@ -1,0 +1,69 @@
+package com.github.dominik48n.party.config;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class SwitchServerConfig {
+
+    private final ConfigList whiteList;
+    private final ConfigList blackList;
+
+    private SwitchServerConfig(final @NotNull ConfigList whiteList,final @NotNull  ConfigList blackList) {
+        this.whiteList = whiteList;
+        this.blackList = blackList;
+    }
+
+    public boolean whiteEnable() {
+        return whiteList.enable();
+    }
+
+    public @NotNull List<Pattern> whitePatternList() {
+        return this.whiteList.toPatternList();
+    }
+
+    public boolean blackEnable() {
+        return blackList.enable();
+    }
+
+    public @NotNull List<Pattern> blackPatternList() {
+        return this.blackList.toPatternList();
+    }
+
+    static @NotNull SwitchServerConfig fromDocument(final @NotNull Document document) {
+        return new SwitchServerConfig(
+                ConfigList.of(document.getDocument("server_white_list")),
+                ConfigList.of(document.getDocument("server_black_list"))
+        );
+    }
+
+    @NotNull Document toDocument() {
+        return new Document()
+                .append("server_white_list", this.whiteList.toDocument())
+                .append("server_black_list", this.blackList.toDocument());
+    }
+
+    private record ConfigList(boolean enable, List<String> stringList) {
+
+        private static @NotNull ConfigList of(final @NotNull Document document) {
+            return new ConfigList(
+                    document.getBoolean("enable", false),
+                    document.getList("regex", Collections.singletonList("^Lobby.*"), Document.stringCollector())
+            );
+        }
+
+        private @NotNull Document toDocument() {
+            return new Document()
+                    .append("enable", enable)
+                    .append("regex", stringList, Document::addJsonConsumer);
+        }
+
+        private @NotNull List<Pattern> toPatternList() {
+            return stringList().stream().map(Pattern::compile).toList();
+        }
+
+    }
+
+}

--- a/common/src/main/java/com/github/dominik48n/party/config/SwitchServerConfig.java
+++ b/common/src/main/java/com/github/dominik48n/party/config/SwitchServerConfig.java
@@ -1,7 +1,6 @@
 package com.github.dominik48n.party.config;
 
 import org.jetbrains.annotations.NotNull;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;

--- a/common/src/main/java/com/github/dominik48n/party/config/SwitchServerConfig.java
+++ b/common/src/main/java/com/github/dominik48n/party/config/SwitchServerConfig.java
@@ -10,7 +10,7 @@ public class SwitchServerConfig {
     private final ConfigList whiteList;
     private final ConfigList blackList;
 
-    private SwitchServerConfig(final @NotNull ConfigList whiteList,final @NotNull  ConfigList blackList) {
+    private SwitchServerConfig(final @NotNull ConfigList whiteList, final @NotNull ConfigList blackList) {
         this.whiteList = whiteList;
         this.blackList = blackList;
     }
@@ -33,15 +33,15 @@ public class SwitchServerConfig {
 
     static @NotNull SwitchServerConfig fromDocument(final @NotNull Document document) {
         return new SwitchServerConfig(
-                ConfigList.of(document.getDocument("server_white_list")),
-                ConfigList.of(document.getDocument("server_black_list"))
+                ConfigList.of(document.getDocument("server_whitelist")),
+                ConfigList.of(document.getDocument("server_blacklist"))
         );
     }
 
     @NotNull Document toDocument() {
         return new Document()
-                .append("server_white_list", this.whiteList.toDocument())
-                .append("server_black_list", this.blackList.toDocument());
+                .append("server_whitelist", this.whiteList.toDocument())
+                .append("server_blacklist", this.blackList.toDocument());
     }
 
     private record ConfigList(boolean enable, List<String> stringList) {

--- a/common/src/main/java/com/github/dominik48n/party/server/SwitchServer.java
+++ b/common/src/main/java/com/github/dominik48n/party/server/SwitchServer.java
@@ -34,37 +34,35 @@ public abstract class SwitchServer<TUser> {
     private final @NotNull UserManager<TUser> userManager;
     private final @NotNull SwitchServerConfig config;
 
-    public SwitchServer(@NotNull UserManager<TUser> userManager, @NotNull SwitchServerConfig switchServerConfig) {
+    public SwitchServer(final @NotNull  UserManager<TUser> userManager, final @NotNull  SwitchServerConfig switchServerConfig) {
         this.userManager = userManager;
         this.config = switchServerConfig;
     }
 
-    public abstract void logJsonProcessingException(JsonProcessingException jsonProcessingException);
+    public abstract void logJsonProcessingException(@NotNull final JsonProcessingException jsonProcessingException);
 
-    protected void handleServerConnected(TUser user, String serverName) {
-        userManager.getPlayer(user)
+    protected void handleServerConnected(final @NotNull TUser user, final @NotNull String serverName) {
+        this.userManager.getPlayer(user)
                 .flatMap(this::handlePartyPlayer)//Get party first
                 .filter(party -> allowServerSwitch(serverName))//Then check regex. Could be more expensive.
                 .ifPresent(party -> connectPartyToServer(serverName, party));
     }
 
-    private static void connectPartyToServer(String serverName, Party party) {
+    private static void connectPartyToServer(final @NotNull String serverName, final @NotNull Party party) {
         get().connectPartyToServer(party, serverName);
     }
 
-    @NotNull
-    private Optional<Party> handlePartyPlayer(PartyPlayer player) {
+    private @NotNull Optional<Party> handlePartyPlayer(final @NotNull PartyPlayer player) {
         return player.partyId()
                 .flatMap(this::getParty)
                 .filter(party -> isPartyLeader(player, party));
     }
 
-    private static boolean isPartyLeader(PartyPlayer player, Party party) {
+    private static boolean isPartyLeader(final @NotNull PartyPlayer player, final @NotNull Party party) {
         return party.isLeader(player.uniqueId());
     }
 
-    @NotNull
-    private Optional<Party> getParty(UUID uuid) {
+    private @NotNull Optional<Party> getParty(UUID uuid) {
         try {
             return get().getParty(uuid);
         } catch (JsonProcessingException jsonProcessingException) {
@@ -75,9 +73,9 @@ public abstract class SwitchServer<TUser> {
 
     private boolean allowServerSwitch(String serverName) {
         //Regex Pattern could be expensive. Maybe cache results.
-        if (config.blackEnable() &&
-                match(config.blackPatternList(), serverName)) {
-            return config.whiteEnable() && match(this.config.whitePatternList(), serverName);
+        if (this.config.blackEnable() &&
+                match(this.config.blackPatternList(), serverName)) {
+            return this.config.whiteEnable() && match(this.config.whitePatternList(), serverName);
         }
 
         return true;

--- a/common/src/main/java/com/github/dominik48n/party/server/SwitchServer.java
+++ b/common/src/main/java/com/github/dominik48n/party/server/SwitchServer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Dominik48N
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dominik48n.party.server;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.dominik48n.party.api.Party;
+import com.github.dominik48n.party.api.player.PartyPlayer;
+import com.github.dominik48n.party.config.SwitchServerConfig;
+import com.github.dominik48n.party.user.UserManager;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.github.dominik48n.party.api.PartyAPI.get;
+
+public abstract class SwitchServer<TUser> {
+
+    private final @NotNull UserManager<TUser> userManager;
+    private final @NotNull SwitchServerConfig switchServerConfig;
+
+    public SwitchServer(@NotNull UserManager<TUser> userManager, @NotNull SwitchServerConfig switchServerConfig) {
+        this.userManager = userManager;
+        this.switchServerConfig = switchServerConfig;
+    }
+
+    public abstract void logJsonProcessingException(JsonProcessingException jsonProcessingException);
+
+    protected void handleServerConnected(TUser user, String serverName) {
+        userManager.getPlayer(user)
+                .flatMap(this::handlePartyPlayer)//Get party first
+                .filter(party -> allowServerSwitch(serverName))//Then check regex. Could be more expensive.
+                .ifPresent(party -> connectPartyToServer(serverName, party));
+    }
+
+    private static void connectPartyToServer(String serverName, Party party) {
+        get().connectPartyToServer(party, serverName);
+    }
+
+    @NotNull
+    private Optional<Party> handlePartyPlayer(PartyPlayer player) {
+        return player.partyId()
+                .flatMap(this::getParty)
+                .filter(party -> isPartyLeader(player, party));
+    }
+
+    private static boolean isPartyLeader(PartyPlayer player, Party party) {
+        return party.isLeader(player.uniqueId());
+    }
+
+    @NotNull
+    private Optional<Party> getParty(UUID uuid) {
+        try {
+            return get().getParty(uuid);
+        } catch (JsonProcessingException jsonProcessingException) {
+            logJsonProcessingException(jsonProcessingException);
+            return Optional.empty();
+        }
+    }
+
+    private boolean allowServerSwitch(String serverName) {
+        //Regex Pattern could be expensive. Maybe cache results.
+        if (switchServerConfig.blackEnable() && match(switchServerConfig.blackPatternList(), serverName)) {
+            return switchServerConfig.whiteEnable() && match(this.switchServerConfig.whitePatternList(), serverName);
+        }
+
+        return true;
+    }
+
+    private boolean match(List<Pattern> patternList, String serverName) {
+        return patternList.stream()
+                .map(pattern -> pattern.matcher(serverName))
+                .anyMatch(Matcher::matches);
+    }
+
+}

--- a/common/src/main/java/com/github/dominik48n/party/server/SwitchServer.java
+++ b/common/src/main/java/com/github/dominik48n/party/server/SwitchServer.java
@@ -22,23 +22,21 @@ import com.github.dominik48n.party.api.player.PartyPlayer;
 import com.github.dominik48n.party.config.SwitchServerConfig;
 import com.github.dominik48n.party.user.UserManager;
 import org.jetbrains.annotations.NotNull;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import static com.github.dominik48n.party.api.PartyAPI.get;
 
 public abstract class SwitchServer<TUser> {
 
     private final @NotNull UserManager<TUser> userManager;
-    private final @NotNull SwitchServerConfig switchServerConfig;
+    private final @NotNull SwitchServerConfig config;
 
     public SwitchServer(@NotNull UserManager<TUser> userManager, @NotNull SwitchServerConfig switchServerConfig) {
         this.userManager = userManager;
-        this.switchServerConfig = switchServerConfig;
+        this.config = switchServerConfig;
     }
 
     public abstract void logJsonProcessingException(JsonProcessingException jsonProcessingException);
@@ -77,8 +75,9 @@ public abstract class SwitchServer<TUser> {
 
     private boolean allowServerSwitch(String serverName) {
         //Regex Pattern could be expensive. Maybe cache results.
-        if (switchServerConfig.blackEnable() && match(switchServerConfig.blackPatternList(), serverName)) {
-            return switchServerConfig.whiteEnable() && match(this.switchServerConfig.whitePatternList(), serverName);
+        if (config.blackEnable() &&
+                match(config.blackPatternList(), serverName)) {
+            return config.whiteEnable() && match(this.config.whitePatternList(), serverName);
         }
 
         return true;

--- a/common/src/main/java/com/github/dominik48n/party/server/SwitchServer.java
+++ b/common/src/main/java/com/github/dominik48n/party/server/SwitchServer.java
@@ -39,7 +39,7 @@ public abstract class SwitchServer<TUser> {
         this.config = switchServerConfig;
     }
 
-    public abstract void logJsonProcessingException(@NotNull final JsonProcessingException jsonProcessingException);
+    public abstract void logJsonProcessingException(final @NotNull JsonProcessingException jsonProcessingException);
 
     protected void handleServerConnected(final @NotNull TUser user, final @NotNull String serverName) {
         this.userManager.getPlayer(user)
@@ -55,11 +55,7 @@ public abstract class SwitchServer<TUser> {
     private @NotNull Optional<Party> handlePartyPlayer(final @NotNull PartyPlayer player) {
         return player.partyId()
                 .flatMap(this::getParty)
-                .filter(party -> isPartyLeader(player, party));
-    }
-
-    private static boolean isPartyLeader(final @NotNull PartyPlayer player, final @NotNull Party party) {
-        return party.isLeader(player.uniqueId());
+                .filter(party -> party.isLeader(player.uniqueId()));
     }
 
     private @NotNull Optional<Party> getParty(UUID uuid) {

--- a/common/src/test/java/com/github/dominik48n/party/config/DocumentTest.java
+++ b/common/src/test/java/com/github/dominik48n/party/config/DocumentTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.platform.commons.util.ReflectionUtils;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -33,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collector;
-
 import static java.util.List.of;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/common/src/test/java/com/github/dominik48n/party/config/DocumentTest.java
+++ b/common/src/test/java/com/github/dominik48n/party/config/DocumentTest.java
@@ -92,35 +92,35 @@ class DocumentTest {
     }
 
     @Test
-    public void testAppendAndGetList() {
-        List<String> list = of("Value1", "Value2", "Value3");
+    void testAppendAndGetList() {
+        final List<String> list = of("Value1", "Value2", "Value3");
 
-        document.append("key", list, Document::addJsonConsumer);
+        this.document.append("key", list, Document::addJsonConsumer);
 
-        List<String> retrievedList = document.getList("key", new ArrayList<>(), Document.stringCollector());
+        List<String> retrievedList = this.document.getList("key", new ArrayList<>(), Document.stringCollector());
 
         assertEquals(list, retrievedList);
     }
 
     @Test
-    public void testAddJsonConsumer() {
-        ArrayNode arrayNode = new ArrayNode(JsonNodeFactory.withExactBigDecimals(false));
+    void testAddJsonConsumer() {
+        final ArrayNode arrayNode = new ArrayNode(JsonNodeFactory.withExactBigDecimals(false));
         Document.addJsonConsumer("Value", arrayNode);
 
         assertEquals("Value", arrayNode.get(0).asText());
     }
 
     @Test
-    public void testStringCollector() {
-        Collector<JsonNode, List<String>, List<String>> collector = Document.stringCollector();
+    void testStringCollector() {
+        final Collector<JsonNode, List<String>, List<String>> collector = Document.stringCollector();
 
-        List<String> stringList1 = new ArrayList<>();
+        final List<String> stringList1 = new ArrayList<>();
         stringList1.add("Value1");
 
-        List<String> stringList2 = new ArrayList<>();
+        final List<String> stringList2 = new ArrayList<>();
         stringList2.add("Value2");
 
-        List<String> combinedList = collector.combiner().apply(stringList1, stringList2);
+        final List<String> combinedList = collector.combiner().apply(stringList1, stringList2);
 
         assertTrue(combinedList.containsAll(stringList1));
         assertTrue(combinedList.containsAll(stringList2));
@@ -128,23 +128,23 @@ class DocumentTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testStringListCombiner() throws InvocationTargetException, IllegalAccessException {
-        List<String> stringList1 = new ArrayList<>();
+    void testStringListCombiner() throws InvocationTargetException, IllegalAccessException {
+        final List<String> stringList1 = new ArrayList<>();
         stringList1.add("Value1");
 
-        List<String> stringList2 = new ArrayList<>();
+        final List<String> stringList2 = new ArrayList<>();
         stringList2.add("Value2");
 
-        Optional<Method> stringListCombiner = ReflectionUtils.findMethod(Document.class,
+        final Optional<Method> stringListCombiner = ReflectionUtils.findMethod(Document.class,
                 "stringListCombiner",
                 List.class, List.class
         );
 
         assertTrue(stringListCombiner.isPresent());
 
-        Method method = stringListCombiner.get();
+        final Method method = stringListCombiner.get();
         method.setAccessible(true);
-        List<String> result = (List<String>) method.invoke(null, stringList1, stringList2);
+        final List<String> result = (List<String>) method.invoke(null, stringList1, stringList2);
         method.setAccessible(false);
 
         assertTrue(result.containsAll(stringList1));

--- a/common/src/test/java/com/github/dominik48n/party/config/SwitchServerConfigTest.java
+++ b/common/src/test/java/com/github/dominik48n/party/config/SwitchServerConfigTest.java
@@ -86,4 +86,5 @@ public class SwitchServerConfigTest {
                 .append("enable", enable)
                 .append("regex", stringList, Document::addJsonConsumer);
     }
+
 }

--- a/common/src/test/java/com/github/dominik48n/party/config/SwitchServerConfigTest.java
+++ b/common/src/test/java/com/github/dominik48n/party/config/SwitchServerConfigTest.java
@@ -18,15 +18,16 @@ package com.github.dominik48n.party.config;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-
 import static com.github.dominik48n.party.config.Document.stringCollector;
 import static java.util.Collections.emptyList;
 import static java.util.List.of;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 
 public class SwitchServerConfigTest {
 
@@ -48,10 +49,10 @@ public class SwitchServerConfigTest {
         Document result = config.toDocument();
 
         // Assert
-        Document serverWhiteListDocument = result.getDocument("server_white_list");
+        Document serverWhiteListDocument = result.getDocument("server_whitelist");
         assertTrue(serverWhiteListDocument.getBoolean("enable", false));
         assertEquals(whiteRegex, serverWhiteListDocument.getList("regex", emptyList(), stringCollector()));
-        Document serverBlackListDocument = result.getDocument("server_black_list");
+        Document serverBlackListDocument = result.getDocument("server_blacklist");
         assertFalse(serverBlackListDocument.getBoolean("enable", true));
         assertEquals(blackRegex, serverBlackListDocument.getList("regex", emptyList(), stringCollector()));
     }
@@ -74,8 +75,8 @@ public class SwitchServerConfigTest {
         boolean blackEnable = false;
 
         Document document = new Document()
-                .append("server_white_list", createDocumentWith(whiteEnable, whiteRegex))
-                .append("server_black_list", createDocumentWith(blackEnable, blackRegex));
+                .append("server_whitelist", createDocumentWith(whiteEnable, whiteRegex))
+                .append("server_blacklist", createDocumentWith(blackEnable, blackRegex));
 
         return SwitchServerConfig.fromDocument(document);
     }

--- a/common/src/test/java/com/github/dominik48n/party/config/SwitchServerConfigTest.java
+++ b/common/src/test/java/com/github/dominik48n/party/config/SwitchServerConfigTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 Dominik48N
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dominik48n.party.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static com.github.dominik48n.party.config.Document.stringCollector;
+import static java.util.Collections.emptyList;
+import static java.util.List.of;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SwitchServerConfigTest {
+
+    private final List<String> whiteRegex = of("Lobby1", "Lobby2");
+    private final List<String> blackRegex = of("PrivateServer");
+
+    private SwitchServerConfig config;
+
+    @BeforeEach
+    void setUp() {
+        this.config = createConfig(whiteRegex, blackRegex);
+    }
+
+    @Test
+    public void testToDocument() {
+        // Arrange
+
+        // Act
+        Document result = config.toDocument();
+
+        // Assert
+        Document serverWhiteListDocument = result.getDocument("server_white_list");
+        assertTrue(serverWhiteListDocument.getBoolean("enable", false));
+        assertEquals(whiteRegex, serverWhiteListDocument.getList("regex", emptyList(), stringCollector()));
+        Document serverBlackListDocument = result.getDocument("server_black_list");
+        assertFalse(serverBlackListDocument.getBoolean("enable", true));
+        assertEquals(blackRegex, serverBlackListDocument.getList("regex", emptyList(), stringCollector()));
+    }
+
+    @Test
+    public void testFromDocument() {
+        // Arrange
+
+        // Act
+
+        // Assert
+        assertTrue(config.whiteEnable());
+        assertLinesMatch(Stream.of("Lobby1", "Lobby2"), config.whitePatternList().stream().map(Pattern::toString));
+        assertFalse(config.blackEnable());
+        assertLinesMatch(Stream.of("PrivateServer"), config.blackPatternList().stream().map(Pattern::toString));
+    }
+
+    private SwitchServerConfig createConfig(List<String> whiteRegex, List<String> blackRegex) {
+        boolean whiteEnable = true;
+        boolean blackEnable = false;
+
+        Document document = new Document()
+                .append("server_white_list", createDocumentWith(whiteEnable, whiteRegex))
+                .append("server_black_list", createDocumentWith(blackEnable, blackRegex));
+
+        return SwitchServerConfig.fromDocument(document);
+    }
+
+    private Document createDocumentWith(boolean enable, List<String> stringList)  {
+        return new Document()
+                .append("enable", enable)
+                .append("regex", stringList, Document::addJsonConsumer);
+    }
+}

--- a/common/src/test/java/com/github/dominik48n/party/config/SwitchServerConfigTest.java
+++ b/common/src/test/java/com/github/dominik48n/party/config/SwitchServerConfigTest.java
@@ -16,6 +16,7 @@
 
 package com.github.dominik48n.party.config;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import java.util.List;
@@ -38,36 +39,36 @@ public class SwitchServerConfigTest {
 
     @BeforeEach
     void setUp() {
-        this.config = createConfig(whiteRegex, blackRegex);
+        this.config = createConfig(this.whiteRegex, this.blackRegex);
     }
 
     @Test
-    public void testToDocument() {
+    void testToDocument() {
         // Arrange
 
         // Act
-        Document result = config.toDocument();
+        final Document result = this.config.toDocument();
 
         // Assert
-        Document serverWhiteListDocument = result.getDocument("server_whitelist");
+        final Document serverWhiteListDocument = result.getDocument("server_whitelist");
         assertTrue(serverWhiteListDocument.getBoolean("enable", false));
-        assertEquals(whiteRegex, serverWhiteListDocument.getList("regex", emptyList(), stringCollector()));
-        Document serverBlackListDocument = result.getDocument("server_blacklist");
+        assertEquals(this.whiteRegex, serverWhiteListDocument.getList("regex", emptyList(), stringCollector()));
+        final Document serverBlackListDocument = result.getDocument("server_blacklist");
         assertFalse(serverBlackListDocument.getBoolean("enable", true));
-        assertEquals(blackRegex, serverBlackListDocument.getList("regex", emptyList(), stringCollector()));
+        assertEquals(this.blackRegex, serverBlackListDocument.getList("regex", emptyList(), stringCollector()));
     }
 
     @Test
-    public void testFromDocument() {
+    void testFromDocument() {
         // Arrange
 
         // Act
 
         // Assert
-        assertTrue(config.whiteEnable());
-        assertLinesMatch(Stream.of("Lobby1", "Lobby2"), config.whitePatternList().stream().map(Pattern::toString));
-        assertFalse(config.blackEnable());
-        assertLinesMatch(Stream.of("PrivateServer"), config.blackPatternList().stream().map(Pattern::toString));
+        assertTrue(this.config.whiteEnable());
+        assertLinesMatch(Stream.of("Lobby1", "Lobby2"), this.config.whitePatternList().stream().map(Pattern::toString));
+        assertFalse(this.config.blackEnable());
+        assertLinesMatch(Stream.of("PrivateServer"), this.config.blackPatternList().stream().map(Pattern::toString));
     }
 
     private SwitchServerConfig createConfig(List<String> whiteRegex, List<String> blackRegex) {
@@ -81,7 +82,7 @@ public class SwitchServerConfigTest {
         return SwitchServerConfig.fromDocument(document);
     }
 
-    private Document createDocumentWith(boolean enable, List<String> stringList)  {
+    private @NotNull Document createDocumentWith(final boolean enable, final @NotNull List<String> stringList)  {
         return new Document()
                 .append("enable", enable)
                 .append("regex", stringList, Document::addJsonConsumer);

--- a/common/src/test/java/com/github/dominik48n/party/server/SwitchServerTest.java
+++ b/common/src/test/java/com/github/dominik48n/party/server/SwitchServerTest.java
@@ -1,0 +1,200 @@
+package com.github.dominik48n.party.server;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.dominik48n.party.api.Party;
+import com.github.dominik48n.party.api.PartyAPI;
+import com.github.dominik48n.party.api.PartyProvider;
+import com.github.dominik48n.party.api.player.PartyPlayer;
+import com.github.dominik48n.party.config.SwitchServerConfig;
+import com.github.dominik48n.party.user.UserManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import static java.util.List.of;
+import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.TOP_DOWN;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class SwitchServerTest {
+
+    private SwitchServer<String> switchServer;
+
+    @Mock
+    private UserManager<String> userManager;
+
+    @Mock
+    private SwitchServerConfig switchServerConfig;
+
+    @Mock
+    private PartyPlayer partyPlayer;
+
+    @Mock
+    private PartyProvider partyProvider;
+
+    @BeforeEach
+    void setUp() throws IllegalAccessException {
+        setPartyProvider();
+        switchServer = createSwitchServer();
+    }
+
+    @Test
+    void handleServerConnected() throws JsonProcessingException {
+        String user = "USER";
+        String serverName = "Lobby3";
+        UUID leaderUUID = UUID.randomUUID();
+        UUID partyUuid = UUID.randomUUID();
+        Party party = createParty(partyUuid, leaderUUID);
+
+        when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
+        when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
+        when(partyPlayer.uniqueId()).thenReturn(leaderUUID);
+        when(partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
+
+        when(switchServerConfig.blackEnable()).thenReturn(true);
+        when(switchServerConfig.blackPatternList()).thenReturn(of(Pattern.compile("^Lobby.*")));
+        when(switchServerConfig.whiteEnable()).thenReturn(true);
+        when(switchServerConfig.whitePatternList()).thenReturn(of(Pattern.compile("Lobby3")));
+
+        switchServer.handleServerConnected(user, serverName);
+
+        verify(partyProvider).connectPartyToServer(party, serverName);
+    }
+
+    @Test
+    void handleServerConnectedFailBecauseNotMatchWhiteList() throws JsonProcessingException {
+        String user = "USER";
+        String serverName = "Lobby2";
+        UUID leaderUUID = UUID.randomUUID();
+        UUID partyUuid = UUID.randomUUID();
+        Party party = createParty(partyUuid, leaderUUID);
+
+        when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
+        when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
+        when(partyPlayer.uniqueId()).thenReturn(leaderUUID);
+        when(partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
+
+        when(switchServerConfig.blackEnable()).thenReturn(true);
+        when(switchServerConfig.blackPatternList()).thenReturn(of(Pattern.compile("^Lobby.*")));
+        when(switchServerConfig.whiteEnable()).thenReturn(true);
+        when(switchServerConfig.whitePatternList()).thenReturn(of(Pattern.compile("Lobby3")));
+
+        switchServer.handleServerConnected(user, serverName);
+
+        verify(partyProvider, never()).connectPartyToServer(any(), any());
+    }
+
+    @Test
+    void handleServerConnectedDisableWhiteList() throws JsonProcessingException {
+        String user = "USER";
+        String serverName = "Lobby3";
+        UUID leaderUUID = UUID.randomUUID();
+        UUID partyUuid = UUID.randomUUID();
+        Party party = createParty(partyUuid, leaderUUID);
+
+        when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
+        when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
+        when(partyPlayer.uniqueId()).thenReturn(leaderUUID);
+        when(partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
+
+        when(switchServerConfig.blackEnable()).thenReturn(true);
+        when(switchServerConfig.blackPatternList()).thenReturn(of(Pattern.compile("^Lobby.*")));
+        when(switchServerConfig.whiteEnable()).thenReturn(false);
+
+        switchServer.handleServerConnected(user, serverName);
+
+        verify(partyProvider, never()).connectPartyToServer(any(), any());
+        verify(switchServerConfig, never()).whitePatternList();
+    }
+
+    @Test
+    void handleServerConnectedDisableBlackList() throws JsonProcessingException {
+        String user = "USER";
+        String serverName = "Lobby3";
+        UUID leaderUUID = UUID.randomUUID();
+        UUID partyUuid = UUID.randomUUID();
+        Party party = createParty(partyUuid, leaderUUID);
+
+        when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
+        when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
+        when(partyPlayer.uniqueId()).thenReturn(leaderUUID);
+        when(partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
+
+        when(switchServerConfig.blackEnable()).thenReturn(false);
+
+        switchServer.handleServerConnected(user, serverName);
+
+        verify(partyProvider).connectPartyToServer(party, serverName);
+        verify(switchServerConfig, never()).blackPatternList();
+        verify(switchServerConfig, never()).whiteEnable();
+        verify(switchServerConfig, never()).whitePatternList();
+    }
+
+
+    @Test
+    void handleServerConnectedNotPartyLeader() throws JsonProcessingException {
+        String user = "USER";
+        String serverName = "Lobby3";
+        UUID leaderUUID = UUID.randomUUID();
+        UUID partyUuid = UUID.randomUUID();
+        Party party = createParty(partyUuid, leaderUUID);
+
+        when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
+        when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
+        when(partyPlayer.uniqueId()).thenReturn(UUID.randomUUID());
+        when(partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
+
+        switchServer.handleServerConnected(user, serverName);
+
+        verify(partyProvider, never()).connectPartyToServer(party, serverName);
+        verify(switchServerConfig, never()).blackEnable();
+    }
+
+    @Test
+    public void expectError() throws JsonProcessingException {
+        String user = "USER";
+        String serverName = "Lobby3";
+        UUID leaderUUID = UUID.randomUUID();
+        UUID partyUuid = UUID.randomUUID();
+        Party party = createParty(partyUuid, leaderUUID);
+
+        when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
+        when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
+        when(partyProvider.getParty(partyUuid)).thenThrow(JsonProcessingException.class);
+
+        switchServer.handleServerConnected(user, serverName);
+
+        verify(partyProvider, never()).connectPartyToServer(party, serverName);
+    }
+
+    private void setPartyProvider() throws IllegalAccessException {
+        Field partyProviderField = ReflectionUtils.findFields(PartyAPI.class, field -> field.getType().equals(PartyProvider.class),
+                TOP_DOWN).get(0);
+        partyProviderField.setAccessible(true);
+        partyProviderField.set(null, partyProvider);
+        partyProviderField.setAccessible(false);
+    }
+
+    private SwitchServer<String> createSwitchServer() {
+        return new SwitchServer<>(userManager, switchServerConfig) {
+            @Override
+            public void logJsonProcessingException(JsonProcessingException jsonProcessingException) { }
+        };
+    }
+
+    //Mockito can not Mock final classes.
+    private Party createParty(UUID partyUuid, UUID leaderUUID) {
+        return new Party(partyUuid, leaderUUID, of(UUID.randomUUID()), 2);
+    }
+}

--- a/common/src/test/java/com/github/dominik48n/party/server/SwitchServerTest.java
+++ b/common/src/test/java/com/github/dominik48n/party/server/SwitchServerTest.java
@@ -59,150 +59,150 @@ class SwitchServerTest {
     private PartyProvider partyProvider;
 
     @BeforeEach
-    public void setUp() throws IllegalAccessException {
+    void setUp() throws IllegalAccessException {
         setPartyProvider();
         switchServer = createSwitchServer();
     }
 
     @Test
-    public void handleServerConnected() throws JsonProcessingException {
+    void handleServerConnected() throws JsonProcessingException {
         final String user = "USER";
         final String serverName = "Lobby3";
         final UUID leaderUUID = UUID.randomUUID();
         final UUID partyUuid = UUID.randomUUID();
         final Party party = createParty(partyUuid, leaderUUID);
 
-        when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
-        when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
-        when(partyPlayer.uniqueId()).thenReturn(leaderUUID);
-        when(partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
+        when(this.userManager.getPlayer(user)).thenReturn(Optional.of(this.partyPlayer));
+        when(this.partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
+        when(this.partyPlayer.uniqueId()).thenReturn(leaderUUID);
+        when(this.partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
 
-        when(switchServerConfig.blackEnable()).thenReturn(true);
-        when(switchServerConfig.blackPatternList()).thenReturn(of(Pattern.compile("^Lobby.*")));
-        when(switchServerConfig.whiteEnable()).thenReturn(true);
-        when(switchServerConfig.whitePatternList()).thenReturn(of(Pattern.compile("Lobby3")));
+        when(this.switchServerConfig.blackEnable()).thenReturn(true);
+        when(this.switchServerConfig.blackPatternList()).thenReturn(of(Pattern.compile("^Lobby.*")));
+        when(this.switchServerConfig.whiteEnable()).thenReturn(true);
+        when(this.switchServerConfig.whitePatternList()).thenReturn(of(Pattern.compile("Lobby3")));
 
-        switchServer.handleServerConnected(user, serverName);
+        this.switchServer.handleServerConnected(user, serverName);
 
-        verify(partyProvider).connectPartyToServer(party, serverName);
+        verify(this.partyProvider).connectPartyToServer(party, serverName);
     }
 
     @Test
-    public void handleServerConnectedFailBecauseNotMatchWhiteList() throws JsonProcessingException {
+    void handleServerConnectedFailBecauseNotMatchWhiteList() throws JsonProcessingException {
         final String user = "USER";
         final String serverName = "Lobby2";
         final UUID leaderUUID = UUID.randomUUID();
         final UUID partyUuid = UUID.randomUUID();
         final Party party = createParty(partyUuid, leaderUUID);
 
-        when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
-        when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
-        when(partyPlayer.uniqueId()).thenReturn(leaderUUID);
-        when(partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
+        when(this.userManager.getPlayer(user)).thenReturn(Optional.of(this.partyPlayer));
+        when(this.partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
+        when(this.partyPlayer.uniqueId()).thenReturn(leaderUUID);
+        when(this.partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
 
-        when(switchServerConfig.blackEnable()).thenReturn(true);
-        when(switchServerConfig.blackPatternList()).thenReturn(of(Pattern.compile("^Lobby.*")));
-        when(switchServerConfig.whiteEnable()).thenReturn(true);
-        when(switchServerConfig.whitePatternList()).thenReturn(of(Pattern.compile("Lobby3")));
+        when(this.switchServerConfig.blackEnable()).thenReturn(true);
+        when(this.switchServerConfig.blackPatternList()).thenReturn(of(Pattern.compile("^Lobby.*")));
+        when(this.switchServerConfig.whiteEnable()).thenReturn(true);
+        when(this.switchServerConfig.whitePatternList()).thenReturn(of(Pattern.compile("Lobby3")));
 
-        switchServer.handleServerConnected(user, serverName);
+        this.switchServer.handleServerConnected(user, serverName);
 
-        verify(partyProvider, never()).connectPartyToServer(any(), any());
+        verify(this.partyProvider, never()).connectPartyToServer(any(), any());
     }
 
     @Test
-    public void handleServerConnectedDisableWhiteList() throws JsonProcessingException {
+    void handleServerConnectedDisableWhiteList() throws JsonProcessingException {
         final String user = "USER";
         final String serverName = "Lobby3";
         final UUID leaderUUID = UUID.randomUUID();
         final UUID partyUuid = UUID.randomUUID();
         final Party party = createParty(partyUuid, leaderUUID);
 
-        when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
-        when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
-        when(partyPlayer.uniqueId()).thenReturn(leaderUUID);
-        when(partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
+        when(this.userManager.getPlayer(user)).thenReturn(Optional.of(this.partyPlayer));
+        when(this.partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
+        when(this.partyPlayer.uniqueId()).thenReturn(leaderUUID);
+        when(this.partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
 
-        when(switchServerConfig.blackEnable()).thenReturn(true);
-        when(switchServerConfig.blackPatternList()).thenReturn(of(Pattern.compile("^Lobby.*")));
-        when(switchServerConfig.whiteEnable()).thenReturn(false);
+        when(this.switchServerConfig.blackEnable()).thenReturn(true);
+        when(this.switchServerConfig.blackPatternList()).thenReturn(of(Pattern.compile("^Lobby.*")));
+        when(this.switchServerConfig.whiteEnable()).thenReturn(false);
 
-        switchServer.handleServerConnected(user, serverName);
+        this.switchServer.handleServerConnected(user, serverName);
 
-        verify(partyProvider, never()).connectPartyToServer(any(), any());
-        verify(switchServerConfig, never()).whitePatternList();
+        verify(this.partyProvider, never()).connectPartyToServer(any(), any());
+        verify(this.switchServerConfig, never()).whitePatternList();
     }
 
     @Test
-    public void handleServerConnectedDisableBlackList() throws JsonProcessingException {
+    void handleServerConnectedDisableBlackList() throws JsonProcessingException {
         final String user = "USER";
         final String serverName = "Lobby3";
         final UUID leaderUUID = UUID.randomUUID();
         final UUID partyUuid = UUID.randomUUID();
         final Party party = createParty(partyUuid, leaderUUID);
 
-        when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
-        when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
-        when(partyPlayer.uniqueId()).thenReturn(leaderUUID);
-        when(partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
+        when(this.userManager.getPlayer(user)).thenReturn(Optional.of(this.partyPlayer));
+        when(this.partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
+        when(this.partyPlayer.uniqueId()).thenReturn(leaderUUID);
+        when(this.partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
 
-        when(switchServerConfig.blackEnable()).thenReturn(false);
+        when(this.switchServerConfig.blackEnable()).thenReturn(false);
 
-        switchServer.handleServerConnected(user, serverName);
+        this.switchServer.handleServerConnected(user, serverName);
 
-        verify(partyProvider).connectPartyToServer(party, serverName);
-        verify(switchServerConfig, never()).blackPatternList();
-        verify(switchServerConfig, never()).whiteEnable();
-        verify(switchServerConfig, never()).whitePatternList();
+        verify(this.partyProvider).connectPartyToServer(party, serverName);
+        verify(this.switchServerConfig, never()).blackPatternList();
+        verify(this.switchServerConfig, never()).whiteEnable();
+        verify(this.switchServerConfig, never()).whitePatternList();
     }
 
 
     @Test
-    public void handleServerConnectedNotPartyLeader() throws JsonProcessingException {
+    void handleServerConnectedNotPartyLeader() throws JsonProcessingException {
         final String user = "USER";
         final String serverName = "Lobby3";
         final UUID leaderUUID = UUID.randomUUID();
         final UUID partyUuid = UUID.randomUUID();
         final Party party = createParty(partyUuid, leaderUUID);
 
-        when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
-        when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
-        when(partyPlayer.uniqueId()).thenReturn(UUID.randomUUID());
-        when(partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
+        when(this.userManager.getPlayer(user)).thenReturn(Optional.of(this.partyPlayer));
+        when(this.partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
+        when(this.partyPlayer.uniqueId()).thenReturn(UUID.randomUUID());
+        when(this.partyProvider.getParty(partyUuid)).thenReturn(Optional.of(party));
 
-        switchServer.handleServerConnected(user, serverName);
+        this.switchServer.handleServerConnected(user, serverName);
 
-        verify(partyProvider, never()).connectPartyToServer(party, serverName);
-        verify(switchServerConfig, never()).blackEnable();
+        verify(this.partyProvider, never()).connectPartyToServer(party, serverName);
+        verify(this.switchServerConfig, never()).blackEnable();
     }
 
     @Test
-    public void expectJsonProcessingException() throws JsonProcessingException {
+    void expectJsonProcessingException() throws JsonProcessingException {
         final String user = "USER";
         final String serverName = "Lobby3";
         final UUID leaderUUID = UUID.randomUUID();
         final UUID partyUuid = UUID.randomUUID();
         final Party party = createParty(partyUuid, leaderUUID);
 
-        when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
-        when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
-        when(partyProvider.getParty(partyUuid)).thenThrow(JsonProcessingException.class);
+        when(this.userManager.getPlayer(user)).thenReturn(Optional.of(this.partyPlayer));
+        when(this.partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
+        when(this.partyProvider.getParty(partyUuid)).thenThrow(JsonProcessingException.class);
 
-        switchServer.handleServerConnected(user, serverName);
+        this.switchServer.handleServerConnected(user, serverName);
 
-        verify(partyProvider, never()).connectPartyToServer(party, serverName);
+        verify(this.partyProvider, never()).connectPartyToServer(party, serverName);
     }
 
     private void setPartyProvider() throws IllegalAccessException {
         Field partyProviderField = ReflectionUtils.findFields(PartyAPI.class, field -> field.getType().equals(PartyProvider.class),
                 TOP_DOWN).get(0);
         partyProviderField.setAccessible(true);
-        partyProviderField.set(null, partyProvider);
+        partyProviderField.set(null, this.partyProvider);
         partyProviderField.setAccessible(false);
     }
 
     private @NotNull SwitchServer<String> createSwitchServer() {
-        return new SwitchServer<>(userManager, switchServerConfig) {
+        return new SwitchServer<>(this.userManager, this.switchServerConfig) {
             @Override
             public void logJsonProcessingException(final @NotNull JsonProcessingException jsonProcessingException) { }
         };

--- a/common/src/test/java/com/github/dominik48n/party/server/SwitchServerTest.java
+++ b/common/src/test/java/com/github/dominik48n/party/server/SwitchServerTest.java
@@ -23,6 +23,7 @@ import com.github.dominik48n.party.api.PartyProvider;
 import com.github.dominik48n.party.api.player.PartyPlayer;
 import com.github.dominik48n.party.config.SwitchServerConfig;
 import com.github.dominik48n.party.user.UserManager;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,18 +59,18 @@ class SwitchServerTest {
     private PartyProvider partyProvider;
 
     @BeforeEach
-    void setUp() throws IllegalAccessException {
+    public void setUp() throws IllegalAccessException {
         setPartyProvider();
         switchServer = createSwitchServer();
     }
 
     @Test
-    void handleServerConnected() throws JsonProcessingException {
-        String user = "USER";
-        String serverName = "Lobby3";
-        UUID leaderUUID = UUID.randomUUID();
-        UUID partyUuid = UUID.randomUUID();
-        Party party = createParty(partyUuid, leaderUUID);
+    public void handleServerConnected() throws JsonProcessingException {
+        final String user = "USER";
+        final String serverName = "Lobby3";
+        final UUID leaderUUID = UUID.randomUUID();
+        final UUID partyUuid = UUID.randomUUID();
+        final Party party = createParty(partyUuid, leaderUUID);
 
         when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
         when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
@@ -87,12 +88,12 @@ class SwitchServerTest {
     }
 
     @Test
-    void handleServerConnectedFailBecauseNotMatchWhiteList() throws JsonProcessingException {
-        String user = "USER";
-        String serverName = "Lobby2";
-        UUID leaderUUID = UUID.randomUUID();
-        UUID partyUuid = UUID.randomUUID();
-        Party party = createParty(partyUuid, leaderUUID);
+    public void handleServerConnectedFailBecauseNotMatchWhiteList() throws JsonProcessingException {
+        final String user = "USER";
+        final String serverName = "Lobby2";
+        final UUID leaderUUID = UUID.randomUUID();
+        final UUID partyUuid = UUID.randomUUID();
+        final Party party = createParty(partyUuid, leaderUUID);
 
         when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
         when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
@@ -110,12 +111,12 @@ class SwitchServerTest {
     }
 
     @Test
-    void handleServerConnectedDisableWhiteList() throws JsonProcessingException {
-        String user = "USER";
-        String serverName = "Lobby3";
-        UUID leaderUUID = UUID.randomUUID();
-        UUID partyUuid = UUID.randomUUID();
-        Party party = createParty(partyUuid, leaderUUID);
+    public void handleServerConnectedDisableWhiteList() throws JsonProcessingException {
+        final String user = "USER";
+        final String serverName = "Lobby3";
+        final UUID leaderUUID = UUID.randomUUID();
+        final UUID partyUuid = UUID.randomUUID();
+        final Party party = createParty(partyUuid, leaderUUID);
 
         when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
         when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
@@ -133,12 +134,12 @@ class SwitchServerTest {
     }
 
     @Test
-    void handleServerConnectedDisableBlackList() throws JsonProcessingException {
-        String user = "USER";
-        String serverName = "Lobby3";
-        UUID leaderUUID = UUID.randomUUID();
-        UUID partyUuid = UUID.randomUUID();
-        Party party = createParty(partyUuid, leaderUUID);
+    public void handleServerConnectedDisableBlackList() throws JsonProcessingException {
+        final String user = "USER";
+        final String serverName = "Lobby3";
+        final UUID leaderUUID = UUID.randomUUID();
+        final UUID partyUuid = UUID.randomUUID();
+        final Party party = createParty(partyUuid, leaderUUID);
 
         when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
         when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
@@ -157,12 +158,12 @@ class SwitchServerTest {
 
 
     @Test
-    void handleServerConnectedNotPartyLeader() throws JsonProcessingException {
-        String user = "USER";
-        String serverName = "Lobby3";
-        UUID leaderUUID = UUID.randomUUID();
-        UUID partyUuid = UUID.randomUUID();
-        Party party = createParty(partyUuid, leaderUUID);
+    public void handleServerConnectedNotPartyLeader() throws JsonProcessingException {
+        final String user = "USER";
+        final String serverName = "Lobby3";
+        final UUID leaderUUID = UUID.randomUUID();
+        final UUID partyUuid = UUID.randomUUID();
+        final Party party = createParty(partyUuid, leaderUUID);
 
         when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
         when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
@@ -176,12 +177,12 @@ class SwitchServerTest {
     }
 
     @Test
-    public void expectError() throws JsonProcessingException {
-        String user = "USER";
-        String serverName = "Lobby3";
-        UUID leaderUUID = UUID.randomUUID();
-        UUID partyUuid = UUID.randomUUID();
-        Party party = createParty(partyUuid, leaderUUID);
+    public void expectJsonProcessingException() throws JsonProcessingException {
+        final String user = "USER";
+        final String serverName = "Lobby3";
+        final UUID leaderUUID = UUID.randomUUID();
+        final UUID partyUuid = UUID.randomUUID();
+        final Party party = createParty(partyUuid, leaderUUID);
 
         when(userManager.getPlayer(user)).thenReturn(Optional.of(partyPlayer));
         when(partyPlayer.partyId()).thenReturn(Optional.of(partyUuid));
@@ -200,15 +201,15 @@ class SwitchServerTest {
         partyProviderField.setAccessible(false);
     }
 
-    private SwitchServer<String> createSwitchServer() {
+    private @NotNull SwitchServer<String> createSwitchServer() {
         return new SwitchServer<>(userManager, switchServerConfig) {
             @Override
-            public void logJsonProcessingException(JsonProcessingException jsonProcessingException) { }
+            public void logJsonProcessingException(final @NotNull JsonProcessingException jsonProcessingException) { }
         };
     }
 
-    //Mockito can not Mock final classes.
-    private Party createParty(UUID partyUuid, UUID leaderUUID) {
-        return new Party(partyUuid, leaderUUID, of(UUID.randomUUID()), 2);
+    // Mockito can not Mock final classes.
+    private @NotNull Party createParty(final @NotNull UUID partyId, final @NotNull UUID leader) {
+        return new Party(partyId, leader, of(UUID.randomUUID()), 2);
     }
 }

--- a/common/src/test/java/com/github/dominik48n/party/server/SwitchServerTest.java
+++ b/common/src/test/java/com/github/dominik48n/party/server/SwitchServerTest.java
@@ -60,8 +60,8 @@ class SwitchServerTest {
 
     @BeforeEach
     void setUp() throws IllegalAccessException {
-        setPartyProvider();
-        switchServer = createSwitchServer();
+        this.setPartyProvider();
+        this.switchServer = this.createSwitchServer();
     }
 
     @Test

--- a/common/src/test/java/com/github/dominik48n/party/server/SwitchServerTest.java
+++ b/common/src/test/java/com/github/dominik48n/party/server/SwitchServerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Dominik48N
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.github.dominik48n.party.server;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -13,12 +29,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.lang.reflect.Field;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
-
 import static java.util.List.of;
 import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.TOP_DOWN;
 import static org.mockito.Mockito.any;

--- a/velocity/src/main/java/com/github/dominik48n/party/velocity/PartyVelocityPlugin.java
+++ b/velocity/src/main/java/com/github/dominik48n/party/velocity/PartyVelocityPlugin.java
@@ -32,14 +32,13 @@ import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
 
 @Plugin(
         id = "party-system",

--- a/velocity/src/main/java/com/github/dominik48n/party/velocity/PartyVelocityPlugin.java
+++ b/velocity/src/main/java/com/github/dominik48n/party/velocity/PartyVelocityPlugin.java
@@ -32,13 +32,14 @@ import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
 
 @Plugin(
         id = "party-system",
@@ -97,7 +98,7 @@ public class PartyVelocityPlugin {
         this.redisManager.subscribes(userManager);
 
         this.server.getEventManager().register(this, new OnlinePlayersListener(userManager, this));
-        this.server.getEventManager().register(this, new SwitchServerListener(userManager, this.logger));
+        this.server.getEventManager().register(this, new SwitchServerListener(userManager, this.config.serverSwitchConfig(), this.logger));
         this.server.getCommandManager().register(
                 this.server.getCommandManager().metaBuilder("party").aliases("p").plugin(this).build(),
                 new VelocityCommandManager(userManager, this)

--- a/velocity/src/main/java/com/github/dominik48n/party/velocity/listener/SwitchServerListener.java
+++ b/velocity/src/main/java/com/github/dominik48n/party/velocity/listener/SwitchServerListener.java
@@ -44,7 +44,7 @@ public class SwitchServerListener extends SwitchServer<Player> {
     }
 
     @Override
-    public void logJsonProcessingException(JsonProcessingException jsonProcessingException) {
+    public void logJsonProcessingException(final @NotNull JsonProcessingException jsonProcessingException) {
         this.logger.error("Failed to get party.", jsonProcessingException);
     }
 }


### PR DESCRIPTION
### Changes Made

- add test for list support in Document
- add ServerSwitchConfigTest
- implement ServerSwitchConfig in ProxyPluginConfig
- create base class for SwitchServer
- add check for black & white list server
- supply serverSwitchConfig for listeners

### Reason for Changes

Include a config entry that allows servers to be blacklisted so that if the party leader joins this server, the party is not pulled along.

It would make sense to support explicit server names, as well as the beginning of a server name. As an example, all servers whose names begin with "Lobby" are directly blacklisted.

### Issues Resolved

Now possible to configurate in config Black and Whitelist for server swapping with enable option

### Checklist

- [ ] I have tested these changes locally
- [X] *(Optional)* I have updated the tests accordingly
- [X] My code follows the established code style guidelines
- [X] I have added/updated necessary comments to my code
