### PR TITLE
Move UpdateChecker Constants to Constants class

### DIFF
--- a/bungeecord/src/main/java/com/github/dominik48n/party/bungee/PartyBungeePlugin.java
+++ b/bungeecord/src/main/java/com/github/dominik48n/party/bungee/PartyBungeePlugin.java
@@ -24,6 +24,7 @@ import com.github.dominik48n.party.bungee.listener.SwitchServerListener;
 import com.github.dominik48n.party.bungee.listener.UpdateCheckerListener;
 import com.github.dominik48n.party.config.ProxyPluginConfig;
 import com.github.dominik48n.party.redis.RedisManager;
+import com.github.dominik48n.party.util.Constants;
 import com.github.dominik48n.party.util.UpdateChecker;
 import java.io.File;
 import java.io.IOException;
@@ -101,7 +102,7 @@ public class PartyBungeePlugin extends Plugin {
         final String currentVersion = this.getDescription().getVersion();
         this.getProxy().getScheduler().schedule(this, () -> {
             try {
-                final String latestVersion = UpdateChecker.latestVersion(UpdateChecker.OWNER, UpdateChecker.REPOSITORY);
+                final String latestVersion = UpdateChecker.latestVersion(Constants.GITHUB_OWNER, Constants.GITHUB_REPOSITORY);
                 if (latestVersion.equals(currentVersion)) return; // Up to date :)
 
                 PartyBungeePlugin.this.getLogger().log(Level.INFO, "There is a new version of the party system: {0}", new Object[] {latestVersion});

--- a/bungeecord/src/main/java/com/github/dominik48n/party/bungee/listener/UpdateCheckerListener.java
+++ b/bungeecord/src/main/java/com/github/dominik48n/party/bungee/listener/UpdateCheckerListener.java
@@ -18,6 +18,7 @@ package com.github.dominik48n.party.bungee.listener;
 
 import com.github.dominik48n.party.bungee.PartyBungeePlugin;
 import com.github.dominik48n.party.config.MessageConfig;
+import com.github.dominik48n.party.util.Constants;
 import com.github.dominik48n.party.util.UpdateChecker;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -42,7 +43,7 @@ public class UpdateCheckerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void handlePostLogin(final PostLoginEvent event) {
         final ProxiedPlayer player = event.getPlayer();
-        if (!player.hasPermission(UpdateChecker.PERMISSION)) return;
+        if (!player.hasPermission(Constants.UPDATE_CHECKER_PERMISSION)) return;
 
         this.plugin.getProxy().getScheduler().runAsync(this.plugin, () -> {
             try {

--- a/bungeecord/src/main/java/com/github/dominik48n/party/bungee/listener/UpdateCheckerListener.java
+++ b/bungeecord/src/main/java/com/github/dominik48n/party/bungee/listener/UpdateCheckerListener.java
@@ -47,7 +47,7 @@ public class UpdateCheckerListener implements Listener {
 
         this.plugin.getProxy().getScheduler().runAsync(this.plugin, () -> {
             try {
-                final String latestVersion = UpdateChecker.latestVersion(UpdateChecker.OWNER, UpdateChecker.REPOSITORY);
+                final String latestVersion = UpdateChecker.latestVersion(Constants.GITHUB_OWNER, Constants.GITHUB_REPOSITORY);
                 if (latestVersion.equals(UpdateCheckerListener.this.plugin.getDescription().getVersion())) return;
 
                 final Component message = UpdateCheckerListener.this.messageConfig.getMessage("general.updates.new_version");

--- a/common/src/main/java/com/github/dominik48n/party/util/Constants.java
+++ b/common/src/main/java/com/github/dominik48n/party/util/Constants.java
@@ -24,5 +24,7 @@ public class Constants {
     public static final int MAXIMUM_MEMBER_LIMIT = 1000;
 
     public static final @NotNull String UPDATE_CHECKER_PERMISSION = "party.updates";
+    public static final @NotNull String GITHUB_OWNER = "Dominik48N";
+    public static final @NotNull String GITHUB_REPOSITORY = "party-system";
 
 }

--- a/common/src/main/java/com/github/dominik48n/party/util/Constants.java
+++ b/common/src/main/java/com/github/dominik48n/party/util/Constants.java
@@ -23,4 +23,6 @@ public class Constants {
     public static final @NotNull String MEMBER_LIMIT_PERMISSION_PREFIX = "party.members.limit.";
     public static final int MAXIMUM_MEMBER_LIMIT = 1000;
 
+    public static final @NotNull String UPDATE_CHECKER_PERMISSION = "party.updates";
+
 }

--- a/common/src/main/java/com/github/dominik48n/party/util/UpdateChecker.java
+++ b/common/src/main/java/com/github/dominik48n/party/util/UpdateChecker.java
@@ -29,7 +29,6 @@ public class UpdateChecker {
 
     public static final @NotNull String OWNER = "Dominik48N";
     public static final @NotNull String REPOSITORY = "party-system";
-    public static final @NotNull String PERMISSION = "party.updates";
 
     /**
      * Retrieves the latest version of a GitHub repository's release.

--- a/common/src/main/java/com/github/dominik48n/party/util/UpdateChecker.java
+++ b/common/src/main/java/com/github/dominik48n/party/util/UpdateChecker.java
@@ -27,9 +27,6 @@ import org.jetbrains.annotations.NotNull;
 
 public class UpdateChecker {
 
-    public static final @NotNull String OWNER = "Dominik48N";
-    public static final @NotNull String REPOSITORY = "party-system";
-
     /**
      * Retrieves the latest version of a GitHub repository's release.
      *

--- a/velocity/src/main/java/com/github/dominik48n/party/velocity/PartyVelocityPlugin.java
+++ b/velocity/src/main/java/com/github/dominik48n/party/velocity/PartyVelocityPlugin.java
@@ -20,6 +20,7 @@ import com.github.dominik48n.party.api.DefaultPartyProvider;
 import com.github.dominik48n.party.api.PartyAPI;
 import com.github.dominik48n.party.config.ProxyPluginConfig;
 import com.github.dominik48n.party.redis.RedisManager;
+import com.github.dominik48n.party.util.Constants;
 import com.github.dominik48n.party.util.UpdateChecker;
 import com.github.dominik48n.party.velocity.listener.OnlinePlayersListener;
 import com.github.dominik48n.party.velocity.listener.SwitchServerListener;
@@ -115,7 +116,7 @@ public class PartyVelocityPlugin {
         final String currentVersion = "@version@";
         this.server.getScheduler().buildTask(this, () -> {
             try {
-                final String latestVersion = UpdateChecker.latestVersion(UpdateChecker.OWNER, UpdateChecker.REPOSITORY);
+                final String latestVersion = UpdateChecker.latestVersion(Constants.GITHUB_OWNER, Constants.GITHUB_REPOSITORY);
                 if (latestVersion.equals(currentVersion)) return; // Up to date :)
 
                 PartyVelocityPlugin.this.logger.info("There is a new version of the party system: {}", latestVersion);

--- a/velocity/src/main/java/com/github/dominik48n/party/velocity/listener/UpdateCheckerListener.java
+++ b/velocity/src/main/java/com/github/dominik48n/party/velocity/listener/UpdateCheckerListener.java
@@ -17,6 +17,7 @@
 package com.github.dominik48n.party.velocity.listener;
 
 import com.github.dominik48n.party.config.MessageConfig;
+import com.github.dominik48n.party.util.Constants;
 import com.github.dominik48n.party.util.UpdateChecker;
 import com.github.dominik48n.party.velocity.PartyVelocityPlugin;
 import com.velocitypowered.api.event.PostOrder;
@@ -49,7 +50,7 @@ public class UpdateCheckerListener {
     @Subscribe(order = PostOrder.LAST)
     public void handlePostLogin(final PostLoginEvent event) {
         final Player player = event.getPlayer();
-        if (!player.hasPermission(UpdateChecker.PERMISSION)) return;
+        if (!player.hasPermission(Constants.UPDATE_CHECKER_PERMISSION)) return;
 
         this.plugin.server().getScheduler().buildTask(this.plugin, () -> {
             try {

--- a/velocity/src/main/java/com/github/dominik48n/party/velocity/listener/UpdateCheckerListener.java
+++ b/velocity/src/main/java/com/github/dominik48n/party/velocity/listener/UpdateCheckerListener.java
@@ -54,7 +54,7 @@ public class UpdateCheckerListener {
 
         this.plugin.server().getScheduler().buildTask(this.plugin, () -> {
             try {
-                final String latestVersion = UpdateChecker.latestVersion(UpdateChecker.OWNER, UpdateChecker.REPOSITORY);
+                final String latestVersion = UpdateChecker.latestVersion(Constants.GITHUB_OWNER, Constants.GITHUB_REPOSITORY);
                 if (latestVersion.equals(UpdateCheckerListener.this.currentVersion)) return;
 
                 player.sendMessage(UpdateCheckerListener.this.messageConfig.getMessage("general.updates.new_version"));


### PR DESCRIPTION
### Changes Made

- The update checker's constant variables have been moved to the Constants class.

### Reason for Changes

- It's cleaner if all the constants are in the same class.

### Checklist

- [ ] I have tested these changes locally
- [ ] *(Optional)* I have updated the tests accordingly
- [x] My code follows the established code style guidelines
- [ ] I have added/updated necessary comments to my code
