### PR TITLE
Super for parent class calls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thank you for considering contributing to PartySystem! Before you start, please 
 ## Code Style
 Please follow the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html) for all code contributions. This will help maintain consistency across the project.
 
-Please note that whenever you access variables or methods from the same class, you always use `this.` do. Otherwise, you simply orientate yourself to the code style you find.
+Please note that whenever you access variables or methods from the same class, you always use `this.` do. When calling the mother class, `super.` is always used! Otherwise, you simply orientate yourself to the code style you find.
 
 ## Annotations
 Please always use `org.jetbrains.annotations.NotNull` and `java.util.Optional<T>`. If Optional is not an option, please use `org.jetbrains.annotations.Nullable`.

--- a/bungeecord/src/main/java/com/github/dominik48n/party/bungee/PartyBungeePlugin.java
+++ b/bungeecord/src/main/java/com/github/dominik48n/party/bungee/PartyBungeePlugin.java
@@ -45,8 +45,8 @@ public class PartyBungeePlugin extends Plugin {
 
     @Override
     public void onEnable() {
-        final File configFile = new File(this.getDataFolder(), ProxyPluginConfig.FILE_NAME);
-        this.getDataFolder().mkdirs();
+        final File configFile = new File(super.getDataFolder(), ProxyPluginConfig.FILE_NAME);
+        super.getDataFolder().mkdirs();
         try {
             this.config = ProxyPluginConfig.fromFile(configFile);
         } catch (final IOException e) {
@@ -54,15 +54,15 @@ public class PartyBungeePlugin extends Plugin {
                 this.config = new ProxyPluginConfig();
                 this.config.writeToFile(configFile);
             } catch (final IOException e1) {
-                this.getLogger().log(Level.SEVERE, "Failed to write configuration file.", e);
+                super.getLogger().log(Level.SEVERE, "Failed to write configuration file.", e);
             }
         }
 
         try {
             this.redisManager = new RedisManager(this.config.redisConfig());
-            this.getLogger().info("The connection to Redis has been established.");
+            super.getLogger().info("The connection to Redis has been established.");
         } catch (final Exception e) {
-            this.getLogger().log(
+            super.getLogger().log(
                     Level.SEVERE,
                     "The connection to redis could not be established. The party system is therefore not fully loaded.",
                     e
@@ -81,14 +81,14 @@ public class PartyBungeePlugin extends Plugin {
 
         final BungeeCommandManager bungeeCommandManager = new BungeeCommandManager(userManager, this);
 
-        this.getProxy().getPluginManager().registerListener(this, new OnlinePlayersListener(userManager, this));
-        this.getProxy().getPluginManager().registerListener(this, new SwitchServerListener(userManager, this.getLogger()));
+        super.getProxy().getPluginManager().registerListener(this, new OnlinePlayersListener(userManager, this));
+        super.getProxy().getPluginManager().registerListener(this, new SwitchServerListener(userManager, super.getLogger()));
 
-        this.getProxy().getPluginManager().registerCommand(
+        super.getProxy().getPluginManager().registerCommand(
                 this,
                 new PartyChatCommand(bungeeCommandManager.commandManager, userManager, this.config().messageConfig())
         );
-        this.getProxy().getPluginManager().registerCommand(this, bungeeCommandManager);
+        super.getProxy().getPluginManager().registerCommand(this, bungeeCommandManager);
 
         if (this.config.updateChecker()) this.registerUpdateChecker();
     }
@@ -100,31 +100,35 @@ public class PartyBungeePlugin extends Plugin {
      */
     private void registerUpdateChecker() {
         final String currentVersion = this.getDescription().getVersion();
-        this.getProxy().getScheduler().schedule(this, () -> {
+        super.getProxy().getScheduler().schedule(this, () -> {
             try {
                 final String latestVersion = UpdateChecker.latestVersion(Constants.GITHUB_OWNER, Constants.GITHUB_REPOSITORY);
                 if (latestVersion.equals(currentVersion)) return; // Up to date :)
 
-                PartyBungeePlugin.this.getLogger().log(Level.INFO, "There is a new version of the party system: {0}", new Object[] {latestVersion});
+                PartyBungeePlugin.super.getLogger().log(
+                        Level.INFO,
+                        "There is a new version of the party system: {0}",
+                        new Object[] {latestVersion}
+                );
             } catch (final IOException | InterruptedException e) {
-                PartyBungeePlugin.this.getLogger().log(Level.SEVERE, "Failed to check latest PartySystem version.", e);
+                PartyBungeePlugin.super.getLogger().log(Level.SEVERE, "Failed to check latest PartySystem version.", e);
             }
         }, 1L, 24L * 60L * 60L, TimeUnit.SECONDS); // Call 1 second after start and daily thereafter.
 
-        this.getProxy().getPluginManager().registerListener(this, new UpdateCheckerListener(this, this.config().messageConfig()));
+        super.getProxy().getPluginManager().registerListener(this, new UpdateCheckerListener(this, this.config().messageConfig()));
     }
 
     @Override
     public void onDisable() {
-        for (final ProxiedPlayer player : this.getProxy().getPlayers()) {
+        for (final ProxiedPlayer player : super.getProxy().getPlayers()) {
             PartyAPI.get().onlinePlayerProvider().logout(player.getUniqueId());
             PartyAPI.get().clearPartyRequest(player.getName());
         }
 
         if (this.redisManager != null) {
-            this.getLogger().info("Close connection to redis...");
+            super.getLogger().info("Close connection to redis...");
             this.redisManager.close();
-        } else this.getLogger().warning("The connection to redis is not closed, because the redis manager is not initialized.");
+        } else super.getLogger().warning("The connection to redis is not closed, because the redis manager is not initialized.");
     }
 
     public @NotNull ProxyPluginConfig config() {

--- a/common/src/main/java/com/github/dominik48n/party/redis/RedisManager.java
+++ b/common/src/main/java/com/github/dominik48n/party/redis/RedisManager.java
@@ -59,7 +59,7 @@ public class RedisManager extends JedisPubSub {
      * Disconnects this RedisManager from the Redis server.
      */
     public void close() {
-        this.unsubscribe();
+        super.unsubscribe();
         this.jedisPool.destroy();
     }
 


### PR DESCRIPTION
### Changes Made

- When we access methods from the parent class, `super` is now used instead of `this`.

### Reason for Changes

- It increases readability.

### Issues Resolved

- Nothing

### Checklist

- [x] I have tested these changes locally
- [ ] *(Optional)* I have updated the tests accordingly
- [x] My code follows the established code style guidelines
- [ ] I have added/updated necessary comments to my code
